### PR TITLE
Allow ENABLE_FEATURE_MAKE_POSIX_202X by itself

### DIFF
--- a/make.h
+++ b/make.h
@@ -179,7 +179,7 @@ struct name {
 #define N_SILENT	0x20	// Build target silently
 #define N_IGNORE	0x40	// Ignore build errors
 #define N_SPECIAL	0x80	// Special target
-#if ENABLE_FEATURE_MAKE_EXTENSIONS
+#if ENABLE_FEATURE_MAKE_EXTENSIONS || ENABLE_FEATURE_MAKE_POSIX_202X
 #define N_MARK		0x100	// Mark for deduplication
 #endif
 #if ENABLE_FEATURE_MAKE_POSIX_202X


### PR DESCRIPTION
This patch allows pdpmake to compile with ENABLE_FEATURE_MAKE_POSIX_202X but ENABLE_FEATURE_MAKE_EXTENSIONS disabled.

The block this is relevant for is this block in make.c:

```
#if ENABLE_FEATURE_MAKE_EXTENSIONS || ENABLE_FEATURE_MAKE_POSIX_202X
        // Reset flag to detect duplicate prerequisites
        if (!quest && !(np->n_flag & N_DOUBLE)) {
                for (rp = np->n_rule; rp; rp = rp->r_next) {
                        for (dp = rp->r_dep; dp; dp = dp->d_next) {
                                dp->d_name->n_flag &= ~N_MARK;
                        }
                }
        }
#endif
```