### PR TITLE
Flush stdout after writing command string to it

### DIFF
--- a/make.c
+++ b/make.c
@@ -56,8 +56,10 @@ docmds(struct name *np, struct cmd *cp)
 		} else if (!sdomake)
 			ssilent = dotouch;
 
-		if (!ssilent)
+		if (!ssilent) {
 			puts(q);
+			fflush(stdout);
+		}
 
 		if (sdomake) {
 			// Get the shell to execute it


### PR DESCRIPTION
Otherwise, if stdout is fully buffered (e.g. because the output is redirected to a file or pipe) then the command string may still be buffered when the command is executed in which case the command string will be written to stdout **after** the command has written its output to stdout.