### PR TITLE
Makefile: Respect $LDFLAGS when linking the final binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BINDIR = $(PREFIX)/bin
 OBJS = check.o input.o macro.o main.o make.o modtime.o rules.o target.o utils.o
 
 make: $(OBJS)
-	$(CC) -o make $(OBJS)
+	$(CC) $(LDFLAGS) -o make $(OBJS)
 
 $(OBJS): make.h
 


### PR DESCRIPTION
Among other things, this allows building with `LDFLAGS=-static make` to obtain a fully statically linked binary. Furthermore, many Linux distributions include distro-specific optimization in LDFLAGS which are, without this change, not picked up for pdpmake.