### PR TITLE
Fix compilation on FreeBSD

### DIFF
--- a/make.h
+++ b/make.h
@@ -13,6 +13,7 @@
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
 #include <unistd.h>
 #include <errno.h>
 #include <time.h>


### PR DESCRIPTION
Compilation would otherwise fail complaining about missing symbols.

Also, should we maybe have includes be alphabetically sorted? 