### PR TITLE
utils: silence GCC -Wanalyzer-null-argument

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -72,7 +72,7 @@ void *
 xmalloc(size_t len)
 {
 	void *ret = malloc(len);
-	if (ret == NULL && errno == ENOMEM)
+	if (ret == NULL)
 		error("out of memory");
 	return ret;
 }
@@ -81,7 +81,7 @@ void *
 xrealloc(void *ptr, size_t len)
 {
 	void *ret = realloc(ptr, len);
-	if (ret == NULL && errno == ENOMEM)
+	if (ret == NULL)
 		error("out of memory");
 	return ret;
 }


### PR DESCRIPTION
The "Nonportable behavior" subsection of the Linux [man-page] indicates that malloc, calloc, and realloc may return NULL without setting errno.

Thus, in non-POSIX platforms, GCC `-fanalyzer` correctly warns about possible NULL dereferences.

[man-page]: https://man7.org/linux/man-pages/man3/malloc.3.html