### PR TITLE
main: silence '-Wstring-plus-int'

### DIFF
--- a/make.h
+++ b/make.h
@@ -107,6 +107,10 @@ extern char **environ;
 # define OPT_OFFSET
 #endif
 
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wstring-plus-int"
+#endif
+
 #if ENABLE_FEATURE_MAKE_EXTENSIONS
 #define OPTSTR1 "+ehij:knqrsSt"
 #elif ENABLE_FEATURE_MAKE_POSIX_202X


### PR DESCRIPTION
Warning found with clang 18.1.6 (some earlier versions also work).

This warning is enabled by default. See [docs].

[docs]: https://clang.llvm.org/docs/DiagnosticsReference.html#wstring-plus-int