### PR TITLE
Add support for suffixes with multiple dots

### DIFF
--- a/input.c
+++ b/input.c
@@ -723,20 +723,23 @@ target_type(char *s)
 			return s_type[ret];
 
 	// Check for an inference rule
-	ret = T_NORMAL;
-	sfx = suffix(s);
-	if (is_suffix(sfx)) {
-		if (s == sfx) {	// Single suffix rule
-			ret = T_INFERENCE | T_NOPREREQ | T_COMMAND;
-		} else {
-			// Suffix is valid, check that prefix is too
-			*sfx = '\0';
-			if (is_suffix(s))
-				ret = T_INFERENCE | T_NOPREREQ | T_COMMAND;
-			*sfx = '.';
-		}
+	for (sfx = s; (sfx = strchr(sfx + 1, '.'));) {
+		if (!is_suffix(sfx))
+			continue;
+
+		// Suffix is valid, check that prefix is too
+		*sfx = '\0';
+		ret = is_suffix(s);
+		*sfx = '.';
+
+		if (ret)
+			return T_INFERENCE | T_NOPREREQ | T_COMMAND;
 	}
-	return ret;
+
+	if (is_suffix(s)) // Single suffix rule
+		return T_INFERENCE | T_NOPREREQ | T_COMMAND;
+
+	return T_NORMAL;
 }
 
 #if ENABLE_FEATURE_MAKE_EXTENSIONS

--- a/rules.c
+++ b/rules.c
@@ -10,7 +10,7 @@
 char *
 suffix(const char *name)
 {
-	char *p = strrchr(name, '.');
+	char *p = strchr(name, '.');
 	return p ? p : (char *)name + strlen(name);
 }
 

--- a/testsuite/make.tests
+++ b/testsuite/make.tests
@@ -100,6 +100,19 @@ x.p:
 '
 cd .. || exit 1; rm -rf make.tempdir 2>/dev/null
 
+# Suffixes with multiple dots are supported
+mkdir make.tempdir && cd make.tempdir || exit 1
+testing "Support multi-dot suffixes" \
+	"make -f -" "touch x.c.c\ncat x.c.c >x.o.o\n" "" '
+.SUFFIXES: .c.c .o.o
+x.o.o:
+x.c.c:
+	touch $@
+.c.c.o.o:
+	cat $< >$@
+'
+cd .. || exit 1; rm -rf make.tempdir 2>/dev/null
+
 # Austin Group defect report 875 clarifies certain aspects of the
 # behaviour of inference rules.  Study of this resulted in a number
 # of changes to pdpmake, though this test passed anyway.


### PR DESCRIPTION
Dot-searching method in suffix() is changed from finding the last dot (strrchr) to the first (strchr), so that the suffix of name "foo.c.depends" is parsed as ".c.depends" instead of ".depends".

The inference rule matching logic in target_type() is extended to an iterative loop to cover possible prefix-suffix combinations of multi-dot sequences. A rule ".x.y.z:" is matched as prefix-suffix pair ".x|.y.z", then ".x.y|.z", and then single-suffix ".x.y.z".