### PR TITLE
Adds basic bootstrap script for non-standard systems

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -24,7 +24,7 @@ done
 ################################
 
 # grab source files from Makefile
-set -- $(cat Makefile | sed '/OBJS.*=/!d; s/.*=\s*//; s/\.o/\.c/g)
+set -- $(cat Makefile | sed '/OBJS.*=/!d; s/.*=\s*//; s/\.o/\.c/g')
 
 tmp="$@"
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+################################
+## Environment Setup ##
+################################
+
+# set CC/CXX/ETC. variables XXX a POSIX array
+set -- CC clang CC gcc CC tcc CC cc
+while [ "$#" -gt 2 ]; do
+    if ! command -v $2 > /dev/null 2>&1; then
+	shift 2
+	continue
+    fi
+
+    first=$1
+    twoth=$2
+
+    eval ": \"\${$first:=$twoth}\"" # only set CC to clang and sundry if it is not already defined
+    shift 2
+done
+
+################################
+## Body ##
+################################
+
+set -- check.c input.c macro.c main.c make.c modtime.c rules.c target.c utils.c
+
+tmp="$@"
+
+while [ "$#" -gt 1 ]; do
+    source="$1"
+    object="${source%.c}.o"
+
+    # build object code
+    set -e
+    $CC $LDFLAGS $CFLAGS -c $source -o $object
+    set +e
+
+    shift
+done
+
+ $("$tmp" | sed 's/.c/.o')
+
+
+
+
+# final binary
+$CC $LDFLAGS -o make $OBJS

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -33,16 +33,10 @@ while [ "$#" -gt 1 ]; do
 
     # build object code
     set -e
-    $CC $LDFLAGS $CFLAGS -c $source -o $object
+    $CC $CFLAGS $CPPFLAGS -c $source -o $object
     set +e
 
     shift
 done
 
- $("$tmp" | sed 's/.c/.o')
-
-
-
-
-# final binary
-$CC $LDFLAGS -o make $OBJS
+$CC $CFLAGS $LDFLAGS -o make $(printf "$tmp" | sed 's/\.c/\.o/')

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -23,7 +23,8 @@ done
 ## Body ##
 ################################
 
-set -- check.c input.c macro.c main.c make.c modtime.c rules.c target.c utils.c
+# grab source files from Makefile
+set -- $(cat Makefile | sed '/OBJS.*=/!d; s/.*=\s*//; s/\.o/\.c/g)
 
 tmp="$@"
 


### PR DESCRIPTION
As someone that enjoys hacking different (often esoteric) devices, it's been a bit of a pain to get development tools on some of these systems, especially for less common build environments like an N3DS, for example.  

This changeset introduces a very basic (POSIX) shell script to bootstrap Make to simply compiling/maintaining projects or building apps from source on aforementioned devices - rather than cross-compiling.  

Please review at your pleasure

<img src="https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fi.pinimg.com%2F736x%2F5d%2F36%2Fa9%2F5d36a9add2cfee865352e537790773c8.jpg&f=1&nofb=1&ipt=2356a170bba0df03d6fc987fb34512226658fab68df4ed26a3b303ebfc25a47f" width="400">