### PR TITLE
make.h: reset getopt correctly on macOS

### DIFF
--- a/make.h
+++ b/make.h
@@ -32,7 +32,7 @@ extern char **environ;
 // Resetting getopt(3) is hopelessly platform-dependent.  If command
 // line options don't work as expected you may need to tweak this.
 // The default should work for GNU libc and OpenBSD.
-#if defined(__FreeBSD__) || defined(__NetBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__)
 # define GETOPT_RESET() do { \
 	extern int optreset; \
 	optind = 1; \


### PR DESCRIPTION
macOS's `getopt(3)` is based on FreeBSD's implementation.
Restarting `getopt()` therefore requires setting both `optind` and `optreset` to `1`.

Refs:

- https://github.com/apple-oss-distributions/Libc/blob/main/stdlib/FreeBSD/getopt.3
- https://man.freebsd.org/cgi/man.cgi?getopt(3)